### PR TITLE
Update bem-md-renderer@0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "bem-md-renderer": "~0.0.1",
+    "bem-md-renderer": "~0.1.0",
     "deep-extend": "^0.3.x",
     "fs-extra": "^0.16.x",
     "fstream": "^1.0.x",


### PR DESCRIPTION
> в bem-md-renderer была бага по генерации якорей.
Тулза расставляла якоря в документах как-будто это один документ, то если есть файл A и в нем заголовок header и файл B и в нем заголовок header, то на выходе у файла A у заголовка header будет якорь header, а у файла B у заголовка header - header-1.