### PR TITLE
Do not remove image's styles

### DIFF
--- a/src/tasks/override-links.js
+++ b/src/tasks/override-links.js
@@ -155,10 +155,11 @@ function recognizeRelativeLinkForLibraryDocs(str, node) {
  * @param {BaseNode} doc node
  * @returns {*}
  */
-function buildSrcForImages(href, doc) {
+function buildSrcForImages(str, href, doc) {
     var docParentUrl = doc && doc.url.replace(/\/\w*\.md/, '/'); // replace last url's part: repo/docs/a.md -> repo/docs
 
-    return href = docParentUrl + href + '?raw=true';
+    // change only src, save styles and attrs
+    return str = str.replace(/src=("|')?.+("|')?/g, 'src="' + docParentUrl + href + '?raw=true"')
 }
 
 /**
@@ -212,8 +213,7 @@ function overrideLinks(content, node, urlHash, lang, doc) {
 
     content = content.replace(REGEXP.SRC, function(str, href){
         //if href is absolute (src="http://..." ) return href
-        href = /^http/.test(href) ? href : buildSrcForImages(href, doc);
-        return '<img src="' + href + '"';
+        return /^http/.test(href) ? str : buildSrcForImages(str, href, doc);
     });
 
     content = content.replace(REGEXP.HREF, function (str, href) {


### PR DESCRIPTION
Before, code from bse-admin remove style for images
`<p><img src="https://img-fotki.yandex.ru/get/15483/158800653.1/0_111ff6_bcf15529_orig"></p>`
after, we left all of attributes
`<p><img style="float: right; padding: 0 0 10px 10px;" title="BEMup в Минске" alt="фотография программы с минского BEMup" src="https://img-fotki.yandex.ru/get/15483/158800653.1/0_111ff6_bcf15529_orig"></p>`