### PR TITLE
Correct link on github

### DIFF
--- a/src/model/nodes/version.js
+++ b/src/model/nodes/version.js
@@ -82,7 +82,7 @@ VersionNode.prototype.setSource = function (version) {
         prev[lang] = {
             title: version.repo,
             deps: version.deps,
-            url: util.format('%s/%s', version.url, version.ref),
+            url: util.format('%s/tree/%s', version.url, version.ref),
             content: (readme && readme.content) ? readme.content[lang] : null,
             repo: repo,
             isLibraryDoc: true


### PR DESCRIPTION
Now link on github has incorrect url `http://github.com/bem/bem-bl/dev` (for example, https://ru.bem.info/libs/bem-components/v2.2.1/, link "Посмотреть на Github").

We add `tree` for correct url-build.